### PR TITLE
refactor: change schedule info endpoints

### DIFF
--- a/src/main/kotlin/com/melowetty/hsepermhelper/controller/PublicScheduleController.kt
+++ b/src/main/kotlin/com/melowetty/hsepermhelper/controller/PublicScheduleController.kt
@@ -3,6 +3,7 @@ package com.melowetty.hsepermhelper.controller
 import com.melowetty.hsepermhelper.domain.model.Response
 import com.melowetty.hsepermhelper.domain.model.lesson.Lesson
 import com.melowetty.hsepermhelper.service.PersonalScheduleService
+import com.melowetty.hsepermhelper.service.ScheduleInfoService
 import io.swagger.v3.oas.annotations.Parameter
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/public/schedule")
 class PublicScheduleController(
     private val personalScheduleService: PersonalScheduleService,
+    private val scheduleInfoService: ScheduleInfoService,
 ) {
     @GetMapping
     fun getScheduleByGroup(
@@ -30,7 +32,7 @@ class PublicScheduleController(
     )
     fun getAvailableCourses(
     ): Response<List<Int>> {
-        return Response(personalScheduleService.getAvailableCourses())
+        return Response(scheduleInfoService.getAvailableCourses())
     }
 
     @GetMapping(
@@ -42,7 +44,7 @@ class PublicScheduleController(
         @RequestParam("course")
         course: Int,
     ): Response<List<String>> {
-        return Response(personalScheduleService.getAvailablePrograms(course))
+        return Response(scheduleInfoService.getAvailablePrograms(course))
     }
 
     @GetMapping(
@@ -57,6 +59,6 @@ class PublicScheduleController(
         @RequestParam("program")
         program: String,
     ): Response<List<String>> {
-        return Response(personalScheduleService.getAvailableGroups(course, program))
+        return Response(scheduleInfoService.getAvailableGroups(course, program))
     }
 }

--- a/src/main/kotlin/com/melowetty/hsepermhelper/controller/PublicScheduleController.kt
+++ b/src/main/kotlin/com/melowetty/hsepermhelper/controller/PublicScheduleController.kt
@@ -27,7 +27,7 @@ class PublicScheduleController(
         return Response(personalScheduleService.getScheduleByGroup(group))
     }
 
-    @Deprecated("Use v1/schedule-info/available-courses")
+    @Deprecated("Use v1/schedule-info/courses")
     @Operation(deprecated = true)
     @GetMapping(
         "available_courses",
@@ -38,7 +38,7 @@ class PublicScheduleController(
         return Response(scheduleInfoService.getAvailableCourses())
     }
 
-    @Deprecated("Use v1/schedule-info/available-programs")
+    @Deprecated("Use v1/schedule-info/programs")
     @Operation(deprecated = true)
     @GetMapping(
         "available_programs",
@@ -52,7 +52,7 @@ class PublicScheduleController(
         return Response(scheduleInfoService.getAvailablePrograms(course))
     }
 
-    @Deprecated("Use v1/schedule-info/available-groups")
+    @Deprecated("Use v1/schedule-info/groups")
     @Operation(deprecated = true)
     @GetMapping(
         "available_groups",

--- a/src/main/kotlin/com/melowetty/hsepermhelper/controller/PublicScheduleController.kt
+++ b/src/main/kotlin/com/melowetty/hsepermhelper/controller/PublicScheduleController.kt
@@ -4,6 +4,7 @@ import com.melowetty.hsepermhelper.domain.model.Response
 import com.melowetty.hsepermhelper.domain.model.lesson.Lesson
 import com.melowetty.hsepermhelper.service.PersonalScheduleService
 import com.melowetty.hsepermhelper.service.ScheduleInfoService
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -26,6 +27,8 @@ class PublicScheduleController(
         return Response(personalScheduleService.getScheduleByGroup(group))
     }
 
+    @Deprecated("Use v1/schedule-info/available-courses")
+    @Operation(deprecated = true)
     @GetMapping(
         "available_courses",
         produces = [MediaType.APPLICATION_JSON_VALUE]
@@ -35,6 +38,8 @@ class PublicScheduleController(
         return Response(scheduleInfoService.getAvailableCourses())
     }
 
+    @Deprecated("Use v1/schedule-info/available-programs")
+    @Operation(deprecated = true)
     @GetMapping(
         "available_programs",
         produces = [MediaType.APPLICATION_JSON_VALUE]
@@ -47,6 +52,8 @@ class PublicScheduleController(
         return Response(scheduleInfoService.getAvailablePrograms(course))
     }
 
+    @Deprecated("Use v1/schedule-info/available-groups")
+    @Operation(deprecated = true)
     @GetMapping(
         "available_groups",
         produces = [MediaType.APPLICATION_JSON_VALUE]

--- a/src/main/kotlin/com/melowetty/hsepermhelper/controller/ScheduleController.kt
+++ b/src/main/kotlin/com/melowetty/hsepermhelper/controller/ScheduleController.kt
@@ -111,6 +111,8 @@ class ScheduleController(
         return Response(schedule)
     }
 
+    @Deprecated("Use v1/schedule-info/available-courses")
+    @Operation(deprecated = true)
     @GetMapping(
         "schedule/available_courses",
         produces = [MediaType.APPLICATION_JSON_VALUE]
@@ -120,6 +122,8 @@ class ScheduleController(
         return Response(scheduleInfoService.getAvailableCourses())
     }
 
+    @Deprecated("Use v1/schedule-info/available-programs")
+    @Operation(deprecated = true)
     @GetMapping(
         "schedule/available_programs",
         produces = [MediaType.APPLICATION_JSON_VALUE]
@@ -132,6 +136,8 @@ class ScheduleController(
         return Response(scheduleInfoService.getAvailablePrograms(course))
     }
 
+    @Deprecated("Use v1/schedule-info/available-groups")
+    @Operation(deprecated = true)
     @GetMapping(
         "schedule/available_groups",
         produces = [MediaType.APPLICATION_JSON_VALUE]

--- a/src/main/kotlin/com/melowetty/hsepermhelper/controller/ScheduleController.kt
+++ b/src/main/kotlin/com/melowetty/hsepermhelper/controller/ScheduleController.kt
@@ -111,7 +111,7 @@ class ScheduleController(
         return Response(schedule)
     }
 
-    @Deprecated("Use v1/schedule-info/available-courses")
+    @Deprecated("Use v1/schedule-info/courses")
     @Operation(deprecated = true)
     @GetMapping(
         "schedule/available_courses",
@@ -122,7 +122,7 @@ class ScheduleController(
         return Response(scheduleInfoService.getAvailableCourses())
     }
 
-    @Deprecated("Use v1/schedule-info/available-programs")
+    @Deprecated("Use v1/schedule-info/programs")
     @Operation(deprecated = true)
     @GetMapping(
         "schedule/available_programs",
@@ -136,7 +136,7 @@ class ScheduleController(
         return Response(scheduleInfoService.getAvailablePrograms(course))
     }
 
-    @Deprecated("Use v1/schedule-info/available-groups")
+    @Deprecated("Use v1/schedule-info/groups")
     @Operation(deprecated = true)
     @GetMapping(
         "schedule/available_groups",

--- a/src/main/kotlin/com/melowetty/hsepermhelper/controller/ScheduleController.kt
+++ b/src/main/kotlin/com/melowetty/hsepermhelper/controller/ScheduleController.kt
@@ -7,6 +7,7 @@ import com.melowetty.hsepermhelper.domain.model.lesson.Lesson
 import com.melowetty.hsepermhelper.domain.model.schedule.Schedule
 import com.melowetty.hsepermhelper.domain.model.schedule.ScheduleInfo
 import com.melowetty.hsepermhelper.service.PersonalScheduleService
+import com.melowetty.hsepermhelper.service.ScheduleInfoService
 import com.melowetty.hsepermhelper.service.UserEventService
 import com.melowetty.hsepermhelper.util.DateUtils
 import io.swagger.v3.oas.annotations.Operation
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController
 class ScheduleController(
     private val personalScheduleService: PersonalScheduleService,
     private val userEventService: UserEventService,
+    private val scheduleInfoService: ScheduleInfoService,
 ) {
     @SecurityRequirement(name = "X-Secret-Key")
     @Operation(
@@ -115,7 +117,7 @@ class ScheduleController(
     )
     fun getAvailableCourses(
     ): Response<List<Int>> {
-        return Response(personalScheduleService.getAvailableCourses())
+        return Response(scheduleInfoService.getAvailableCourses())
     }
 
     @GetMapping(
@@ -127,7 +129,7 @@ class ScheduleController(
         @RequestParam("course")
         course: Int,
     ): Response<List<String>> {
-        return Response(personalScheduleService.getAvailablePrograms(course))
+        return Response(scheduleInfoService.getAvailablePrograms(course))
     }
 
     @GetMapping(
@@ -142,7 +144,7 @@ class ScheduleController(
         @RequestParam("program")
         program: String,
     ): Response<List<String>> {
-        return Response(personalScheduleService.getAvailableGroups(course, program))
+        return Response(scheduleInfoService.getAvailableGroups(course, program))
     }
 
     @GetMapping(

--- a/src/main/kotlin/com/melowetty/hsepermhelper/controller/ScheduleInfoController.kt
+++ b/src/main/kotlin/com/melowetty/hsepermhelper/controller/ScheduleInfoController.kt
@@ -1,0 +1,53 @@
+package com.melowetty.hsepermhelper.controller
+
+import com.melowetty.hsepermhelper.domain.model.Response
+import com.melowetty.hsepermhelper.service.ScheduleInfoService
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("v1/schedule-info")
+class ScheduleInfoController (
+    private val scheduleInfoService: ScheduleInfoService
+){
+    @GetMapping(
+        "available-courses",
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun getAvailableCourses(
+    ): Response<List<Int>> {
+        return Response(scheduleInfoService.getAvailableCourses())
+    }
+
+    @GetMapping(
+        "available-programs",
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun getAvailablePrograms(
+        @Parameter(description = "Номер курса")
+        @RequestParam("course")
+        course: Int,
+    ): Response<List<String>> {
+        return Response(scheduleInfoService.getAvailablePrograms(course))
+    }
+
+    @GetMapping(
+        "available-groups",
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun getAvailableGroups(
+        @Parameter(description = "Номер курса")
+        @RequestParam("course")
+        course: Int,
+        @Parameter(description = "Образовательная программа")
+        @RequestParam("program")
+        program: String,
+    ): Response<List<String>> {
+        return Response(scheduleInfoService.getAvailableGroups(course, program))
+    }
+}

--- a/src/main/kotlin/com/melowetty/hsepermhelper/controller/ScheduleInfoController.kt
+++ b/src/main/kotlin/com/melowetty/hsepermhelper/controller/ScheduleInfoController.kt
@@ -16,7 +16,7 @@ class ScheduleInfoController (
     private val scheduleInfoService: ScheduleInfoService
 ){
     @GetMapping(
-        "available-courses",
+        "courses",
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
     fun getAvailableCourses(
@@ -25,7 +25,7 @@ class ScheduleInfoController (
     }
 
     @GetMapping(
-        "available-programs",
+        "programs",
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
     fun getAvailablePrograms(
@@ -37,7 +37,7 @@ class ScheduleInfoController (
     }
 
     @GetMapping(
-        "available-groups",
+        "groups",
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
     fun getAvailableGroups(

--- a/src/main/kotlin/com/melowetty/hsepermhelper/service/PersonalScheduleService.kt
+++ b/src/main/kotlin/com/melowetty/hsepermhelper/service/PersonalScheduleService.kt
@@ -117,18 +117,6 @@ class PersonalScheduleService(
         return ScheduleUtils.getLessonsAtDateInWeekSchedule(schedule, tomorrowDate)
     }
 
-    fun getAvailableCourses(): List<Int> {
-        return excelScheduleService.getAvailableCourses()
-    }
-
-    fun getAvailablePrograms(course: Int): List<String> {
-        return excelScheduleService.getAvailablePrograms(course = course)
-    }
-
-    fun getAvailableGroups(course: Int, program: String): List<String> {
-        return excelScheduleService.getAvailableGroups(course = course, program = program)
-    }
-
     fun getAvailableLessonsForHiding(telegramId: Long): List<AvailableLessonForHiding> {
         val user = userService.getByTelegramId(telegramId)
         return excelScheduleService.getAvailableLessonsForHiding(user)

--- a/src/main/kotlin/com/melowetty/hsepermhelper/service/ScheduleInfoService.kt
+++ b/src/main/kotlin/com/melowetty/hsepermhelper/service/ScheduleInfoService.kt
@@ -1,0 +1,7 @@
+package com.melowetty.hsepermhelper.service
+
+interface ScheduleInfoService {
+    fun getAvailableCourses(): List<Int>
+    fun getAvailablePrograms(course: Int): List<String>
+    fun getAvailableGroups(course: Int, program: String): List<String>
+}

--- a/src/main/kotlin/com/melowetty/hsepermhelper/service/impl/ScheduleInfoServiceImpl.kt
+++ b/src/main/kotlin/com/melowetty/hsepermhelper/service/impl/ScheduleInfoServiceImpl.kt
@@ -1,0 +1,22 @@
+package com.melowetty.hsepermhelper.service.impl
+
+import com.melowetty.hsepermhelper.service.ExcelScheduleService
+import com.melowetty.hsepermhelper.service.ScheduleInfoService
+import org.springframework.stereotype.Service
+
+@Service
+class ScheduleInfoServiceImpl(
+    private val excelScheduleService: ExcelScheduleService,
+) : ScheduleInfoService {
+    override fun getAvailableCourses(): List<Int> {
+        return excelScheduleService.getAvailableCourses()
+    }
+
+    override fun getAvailablePrograms(course: Int): List<String> {
+        return excelScheduleService.getAvailablePrograms(course = course)
+    }
+
+    override fun getAvailableGroups(course: Int, program: String): List<String> {
+        return excelScheduleService.getAvailableGroups(course = course, program = program)
+    }
+}


### PR DESCRIPTION
Переместил получение доступных курсов, групп и программ из PersonalScheduleService в ScheduleInfoService
Переместил эндпоинты для получения доступных курсов, групп и программ в ScheduleInfoController
Старые эндпоинты помечены как deprecated

Получение курсов - v/schedule-info/available-courses
Получение групп - v/schedule-info/available-groups
Получение программ - v/schedule-info/available-programs